### PR TITLE
style: apply cargo fmt and fix doc comment syntax

### DIFF
--- a/examples/config_example.rs
+++ b/examples/config_example.rs
@@ -6,12 +6,9 @@
 //! 3. Create profiles based on configuration
 //! 4. Use the configured profiles for cryptographic operations
 
-use pqc_iiot::{
-    config::Config,
-    crypto::profile::ProfileKyberFalcon,
-};
 #[cfg(feature = "dilithium")]
 use pqc_iiot::crypto::profile::{ProfileKyberDilithium, ProfileSaberDilithium};
+use pqc_iiot::{config::Config, crypto::profile::ProfileKyberFalcon};
 // use pqc_iiot::crypto::traits::*;
 use pqc_iiot::crypto::profile::CryptoProfileTrait;
 

--- a/examples/crypto_examples.rs
+++ b/examples/crypto_examples.rs
@@ -7,9 +7,9 @@
 //! - Key Rotation
 //! - Performance Metrics
 
-use pqc_iiot::{Falcon, FalconSecurityLevel, Kyber, KyberSecurityLevel};
 #[cfg(feature = "dilithium")]
 use pqc_iiot::{Dilithium, DilithiumSecurityLevel};
+use pqc_iiot::{Falcon, FalconSecurityLevel, Kyber, KyberSecurityLevel};
 #[cfg(feature = "saber")]
 use pqc_iiot::{Saber, SaberSecurityLevel};
 // use pqc_iiot::crypto::traits::{KeyRotation, Metrics, PqcKEM, PqcSignature, SecurityLevel};

--- a/examples/iiot_secure_comm.rs
+++ b/examples/iiot_secure_comm.rs
@@ -8,8 +8,6 @@ use pqc_iiot::{coap_secure::SecureCoapClient, mqtt_secure::SecureMqttClient};
 use std::net::SocketAddr;
 // use tokio::runtime::Runtime;
 
-
-
 fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     // let rt = Runtime::new()?;

--- a/examples/profile_example.rs
+++ b/examples/profile_example.rs
@@ -7,9 +7,7 @@
 //! 4. Sign and verify messages
 //! 5. Handle errors
 
-use pqc_iiot::crypto::profile::{
-    CryptoProfileTrait, ProfileKyberFalcon,
-};
+use pqc_iiot::crypto::profile::{CryptoProfileTrait, ProfileKyberFalcon};
 #[cfg(feature = "dilithium")]
 use pqc_iiot::crypto::profile::{ProfileKyberDilithium, ProfileSaberDilithium};
 

--- a/src/security/hybrid.rs
+++ b/src/security/hybrid.rs
@@ -13,7 +13,7 @@ use rand::{RngCore, SeedableRng};
 const NONCE_SIZE: usize = 12;
 
 /// Hybrid encryption packet structure:
-/// [ Capsule Length (2 bytes BE) ] [ Capsule ] [ Nonce (12 bytes) ] [ Ciphertext (includes Tag) ]
+/// \[ Capsule Length (2 bytes BE) \] \[ Capsule \] \[ Nonce (12 bytes) \] \[ Ciphertext (includes Tag) \]
 pub fn encrypt(target_pk: &[u8], plaintext: &[u8]) -> Result<Vec<u8>> {
     // 1. Determine Kyber level from Key Length
     let kyber = match target_pk.len() {
@@ -65,7 +65,7 @@ pub fn encrypt(target_pk: &[u8], plaintext: &[u8]) -> Result<Vec<u8>> {
 ///
 /// Expectations:
 /// - My Kyber Secret Key (`my_sk`) matches the public key used for encryption.
-///   Packet format: `[ Length(2) ] [ Capsule ] [ Nonce(12) ] [ Ciphertext ]`
+///   Packet format: `\[ Length(2) \] \[ Capsule \] \[ Nonce(12) \] \[ Ciphertext \]`
 pub fn decrypt(my_sk: &[u8], packet: &[u8]) -> Result<Vec<u8>> {
     // 1. Parse header
     if packet.len() < 2 {

--- a/src/security/provider.rs
+++ b/src/security/provider.rs
@@ -10,7 +10,6 @@ use pqcrypto_kyber::kyber1024::{
 use pqcrypto_traits::kem::{Ciphertext as _, SecretKey as _, SharedSecret};
 use pqcrypto_traits::sign::{DetachedSignature, SecretKey as _};
 
-
 /// Trait for abstracting cryptographic operations.
 /// This allows integrating Hardware Security Modules (HSM), TPMs, or TEEs.
 pub trait SecurityProvider: Send + Sync {


### PR DESCRIPTION
- Fix unescaped brackets in src/security/hybrid.rs to satisfy rustdoc.
- Apply cargo fmt to examples/ and src/security/provider.rs to satisfy CI linting.