### PR TITLE
fix(docs): resolve deployment and rustdoc errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Approximate memory requirements:
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License.
 
 ## Contributing
 

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -1,0 +1,8 @@
+/* Custom styles for PQC-IIoT documentation */
+.sidebar {
+    background-color: #f7f7f7;
+}
+
+.content {
+    font-family: 'Open Sans', sans-serif;
+}


### PR DESCRIPTION
- Create docs/custom.css to fix mdBook build failure.
- Fix broken LICENSE link in README.md to resolve rustdoc warnings.