### PR TITLE
security: add RoT boundary, OSCORE CoAP, and hybrid MQTT session PCS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +334,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cbindgen"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
+dependencies = [
+ "heck",
+ "indexmap 2.13.0",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+ "tempfile",
+ "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,10 +363,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "ccm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae3c82e4355234767756212c570e29833699ab63e6ffd161887314cc5b43847"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
 
 [[package]]
 name = "ciborium"
@@ -365,6 +448,18 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -415,6 +510,47 @@ checksum = "3b4859ead43cef7e14593c5238cb3dd8800f41ade206bdf08c44c51f2d943fd3"
 dependencies = [
  "lru_time_cache",
 ]
+
+[[package]]
+name = "coap-message"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "185d26bfc9862ae17a065d361725e2301072125cb7200836d4b795285fded1f7"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "coap-message-implementations"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d3a60b3b05ac004a1b7f3555a7b612082c6a7661461ae7fa4ce8a360d79028"
+dependencies = [
+ "coap-message",
+ "coap-message-utils",
+ "coap-numbers",
+ "document-features",
+ "heapless",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "coap-message-utils"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6b17f1db1e77a315a5c15d420f667e178f45ba17d2f4465c269343a71e58b7"
+dependencies = [
+ "coap-message",
+ "coap-numbers",
+ "document-features",
+ "minicbor",
+]
+
+[[package]]
+name = "coap-numbers"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46b16e7664cd0c1bb97bd3a3e1c10626862919158fc9f5ba141786d00c8739e5"
 
 [[package]]
 name = "colorchoice"
@@ -584,6 +720,15 @@ name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
 
 [[package]]
 name = "dunce"
@@ -1056,10 +1201,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "liboscore"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96e8de2909bb84c13ba2903035565fe1e8f41773cf1f6e055c0744998672857"
+dependencies = [
+ "bindgen",
+ "cbindgen",
+ "cc",
+ "coap-message",
+ "coap-message-implementations",
+ "coap-numbers",
+ "liboscore-cryptobackend",
+ "liboscore-msgbackend",
+ "pretty-hex",
+]
+
+[[package]]
+name = "liboscore-cryptobackend"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f31f61ce4184d3ea5a521700bf2bba3523165b04b63b449284b5f531244250"
+dependencies = [
+ "aead",
+ "aes",
+ "aes-gcm",
+ "ccm",
+ "chacha20poly1305",
+ "heapless",
+ "hkdf",
+ "hmac",
+ "sha2",
+ "typenum",
+]
+
+[[package]]
+name = "liboscore-msgbackend"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83c81a5585908bb8667fdcd4b86bd3d0e0bbce34bf1dba2ca87112284fea2b48"
+dependencies = [
+ "coap-message",
+ "coap-message-implementations",
+ "coap-numbers",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -1137,7 +1344,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -1173,6 +1380,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minicbor"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70eae6d4f18f7d76877fe7b13f0bc21f7c2b7239d2041c338335f7b388d0dd7"
 
 [[package]]
 name = "minimal-lexical"
@@ -1426,6 +1639,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5da3b0203fd7ee5720aa0b5e790b591aa5d3f41c3ed2c34a3a393382198af2f7"
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1469,12 +1693,15 @@ dependencies = [
  "base64 0.22.1",
  "cfg-if",
  "coap-lite",
+ "coap-message",
+ "coap-message-implementations",
  "criterion",
  "env_logger",
  "heapless",
  "hex",
  "hkdf",
  "hmac",
+ "liboscore",
  "log",
  "pqcrypto-falcon",
  "pqcrypto-hqc",
@@ -1579,6 +1806,22 @@ name = "pqcrypto-traits"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e851c7654eed9e68d7d27164c454961a616cf8c203d500607ef22c737b51bb"
+
+[[package]]
+name = "pretty-hex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a65843dfefbafd3c879c683306959a6de478443ffe9c9adf02f5976432402d7"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1802,7 +2045,7 @@ dependencies = [
  "http",
  "log",
  "pollster",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -1824,7 +2067,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slab",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1845,6 +2088,12 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -1974,6 +2223,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -2136,7 +2394,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2144,6 +2411,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2214,9 +2492,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -2229,6 +2522,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2236,10 +2538,25 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.13.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "winnow 0.5.40",
 ]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.1",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -2627,6 +2944,18 @@ checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,12 @@ saber = ["pqcrypto-saber"]
 
 coap = []
 coap-std = ["std", "coap", "dep:coap-lite"]
+coap-oscore = [
+    "coap-std",
+    "dep:liboscore",
+    "dep:coap-message",
+    "dep:coap-message-implementations",
+]
 
 config = ["std", "serde", "toml", "dep:serde_json"]
 default = [
@@ -74,9 +80,12 @@ profile-saber-dilithium = []
 [dependencies]
 cfg-if = "1.0"
 coap-lite = {version = "0.9", optional = true}
+coap-message = { version = "0.3.6", optional = true, default-features = false }
+coap-message-implementations = { version = "0.1.10", optional = true, default-features = false }
 # heapless 0.7 pulls `atomic-polyfill` on some targets (RUSTSEC-2023-0089). 0.9 moved to
 # `portable-atomic`, reducing exposure to unmaintained crates.
 heapless = { version = "0.9.2", default-features = false }
+liboscore = { version = "0.2.7", optional = true, default-features = false }
 pqcrypto-falcon = {version = "0.2.10", optional = true, default-features = false}
 pqcrypto-mlkem = {version = "0.1.1", optional = true, default-features = false}
 pqcrypto-traits = { version = "0.3.4", default-features = false }

--- a/SECURITY_INVARIANTS.md
+++ b/SECURITY_INVARIANTS.md
@@ -184,13 +184,19 @@ This prevents broker-mediated session splicing and downgrade/replay of old sessi
 In this codebase, the design target is:
 
 - **DH-ratchet** inside sessions (PCS against classical compromise).
-- **KEM refresh** via session re-handshake policy (PQC refresh, and PCS reset when bidirectional traffic is absent).
+- **Hybrid DH+KEM root updates** (v4) on DH transitions and policy-driven sender refresh to provide an in-session PQC refresh signal and downgrade resistance.
 
 Regression coverage should include:
 
 - topic binding (ciphertext replayed on another topic must fail)
 - replay rejection (duplicate packet must fail)
 - bounded out-of-order acceptance within a skip window
+- downgrade rejection: DH transition without the expected KEM material after establishment must fail
+
+Regression coverage:
+
+- `tests/mqtt_invariants.rs::mqtt_session_ratchet_establishes_and_binds_topic_and_rejects_replay`
+- `tests/mqtt_invariants.rs::mqtt_session_v4_rejects_dh_ratchet_without_kem_after_established`
 
 ---
 
@@ -198,7 +204,7 @@ Regression coverage should include:
 
 **Invariant:** Signed payloads are authenticity-only and MUST NOT be described as transport security.
 
-**Invariant:** Custom session encryption is not OSCORE/DTLS and MUST be marked experimental.
+**Invariant:** OSCORE mode is the standards-aligned CoAP security context. Custom session encryption is not OSCORE/DTLS and MUST be marked experimental (not the compliance baseline).
 
 For IIoT-critical deployments, the “industrial path” is:
 
@@ -221,4 +227,3 @@ The current model is a functional placeholder:
 Any production-grade claim requires:
 
 - EK/AK separation, manufacturer chain, PCR policy, event log, and verifier policy definition.
-

--- a/docs/coap.md
+++ b/docs/coap.md
@@ -1,11 +1,12 @@
 # CoAP Security (What Exists vs. What Is “Industrial”)
 
-This crate currently exposes **two CoAP security modes** under `pqc_iiot::coap_secure` when `coap-std` is enabled:
+This crate currently exposes **three CoAP security modes** under `pqc_iiot::coap_secure` when `coap-std` is enabled:
 
 1. `SecureCoapClient`: **signed payloads** (authenticity only).
 2. `SecureCoapSessionClient` / `SecureCoapSessionServer`: a **custom session + symmetric ratchet** that provides confidentiality + integrity + replay protection at the application layer.
+3. `SecureCoapOscoreClient`: **OSCORE (RFC 8613)** message protection (feature-gated under `coap-oscore`).
 
-Neither mode is a standards-compliant replacement for **OSCORE (RFC 8613)** or **DTLS**. For critical IIoT deployments where interoperability and compliance matter, OSCORE/DTLS is still the correct transport/security boundary.
+Only (3) is standards-aligned at the CoAP layer. The custom session mode is useful as a building block, but it is not interoperable, and must be treated as experimental for compliance-driven deployments.
 
 ## Threat Model (Practical)
 
@@ -78,13 +79,47 @@ let resp = client.get(server, "test/resource").unwrap();
 assert!(!resp.message.payload.is_empty());
 ```
 
-## “Industrial” Path (OSCORE/DTLS)
+## Mode C: OSCORE (RFC 8613) (`SecureCoapOscoreClient`)
+
+When `coap-oscore` is enabled, the crate can apply OSCORE protection to CoAP requests/responses using `liboscore`.
+
+What this gives you:
+
+- Standard OSCORE option framing and COSE object protection for CoAP.
+- Authenticated encryption of the CoAP message (code/options/payload) under an OSCORE security context.
+
+What this does **not** give you (yet):
+
+- EDHOC (RFC 9528) or another standard authenticated key establishment. You must provision the OSCORE context (master secret + sender/recipient IDs + context ID) out of band.
+- A DTLS record layer.
+
+### Usage Sketch
+
+```rust
+use pqc_iiot::coap_secure::{OscoreConfig, SecureCoapOscoreClient};
+use std::net::SocketAddr;
+
+let server: SocketAddr = "127.0.0.1:5683".parse().unwrap();
+
+let master_secret = vec![0x42u8; 32];
+let mut cfg = OscoreConfig::psk(master_secret, b"client".to_vec(), b"server".to_vec());
+cfg.context_id = Some(b"ctx1".to_vec());
+
+let mut client = SecureCoapOscoreClient::new(cfg).unwrap();
+let resp = client.post(server, "oscore/echo", b"hello").unwrap();
+assert!(!resp.message.payload.is_empty());
+```
+
+## “Industrial” Path (OSCORE/DTLS + AKE)
 
 If the release target is **critical IIoT**, the correct endpoint is not “custom crypto in a CoAP module”; it is a **standards-defined transport/security context** with explicit compliance story:
 
 - **OSCORE** for CoAP over UDP, typically with **EDHOC** for key establishment.
 - **DTLS** for securing UDP transport when OSCORE is not viable.
 
-This crate currently treats OSCORE/DTLS as out-of-scope for the `coap-std` implementation and documents the custom session mode as a practical building block, not an interoperability baseline.
+This crate implements OSCORE message protection (feature `coap-oscore`) but does not yet implement a standards-based authenticated key establishment (EDHOC) nor DTLS. For production fleets, treat the OSCORE context as a provisioned credential and define operational rotation/revocation semantics at the control plane.
 
-If you want this repository to be “market standard”, the next concrete engineering step is to add an OSCORE/DTLS backend (feature-gated) and make the custom session mode explicitly “experimental / internal”.
+If you want this repository to be “market standard”, the next concrete engineering steps are:
+
+- add EDHOC (or another standard AKE) to provision/refresh OSCORE contexts, and/or add DTLS as an alternative transport security backend, and
+- keep the custom session mode explicitly “experimental / internal” (not the compliance baseline).

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -132,12 +132,12 @@ Fleet security policy is a CA-signed update stream (not broker-trusted configura
 
 Policy is treated as an explicit **security gate**:
 
-- `require_sessions`: disallows v1 per-message hybrid encryption and requires v3 forward-secure sessions (double ratchet).
+- `require_sessions`: disallows v1 per-message hybrid encryption and requires v4 forward-secure sessions (hybrid DH+KEM double ratchet).
 - `min_revocation_seq`: fail-closed until emergency revocations are caught up.
 - `ttl_secs`: when secure time is available, new handshakes and encrypted sends fail-closed once the policy becomes stale.
 - `require_rollback_resistant_storage`: fail-closed unless the provider backend is rollback resistant.
 
-## Forward-Secure Sessions (v3: Double Ratchet)
+## Forward-Secure Sessions (v4: Hybrid DH+KEM Double Ratchet)
 
 Per-message hybrid encryption (`publish_encrypted`) is simple but does **not** provide post-compromise security (PCS): if a peer identity key is compromised, historical traffic is still safe (PQC), but the attacker can forge traffic until revocation/rotation and the receiver has to verify signatures on every packet.
 
@@ -145,11 +145,12 @@ For critical IIoT deployments, the crate supports forward-secure authenticated s
 
 - Session establishment is authenticated by long-term Falcon identities (no broker trust).
 - Initial shared secret is hybrid: Kyber (PQC) + X25519 (classical) handshake DH.
-- Session traffic uses a DH-driven **double ratchet**:
+- Session traffic uses a **double ratchet** with hybrid root updates:
   - per-message symmetric ratchet (KDF chain) for forward secrecy
-  - periodic DH ratchet steps for PCS recovery after compromise ends (when bidirectional traffic exists)
+  - DH ratchet steps for PCS recovery after compromise ends
+  - optional Kyber KEM secrets injected into root updates on DH transitions and policy-driven sender refresh
 
-**Important:** the DH ratchet step is X25519 (classical). That gives PCS against a classical attacker who is no longer on the endpoint, but it is not “post-quantum PCS”. For PQC refresh, fleets should enforce periodic session re-handshakes (Kyber + X25519) via policy (`session_rekey_after_msgs` / `session_rekey_after_secs`) until a KEM-based in-session ratchet exists.
+**Important:** classical DH is still X25519, but v4 can inject a Kyber KEM shared secret into the root KDF on ratchet transitions and on policy-driven sender refresh. This gives a practical PQC refresh signal inside established sessions without requiring a full re-handshake for every rotation.
 
 ### Handshake (topics + messages)
 
@@ -173,7 +174,7 @@ Both messages are JSON and include a detached Falcon signature over a canonical 
 Session traffic is a binary packet carried as MQTT payload:
 
 ```
-[sender_id_len:u16][sender_id][v=3][session_id:16][dh_pub:32][msg_num:u32][pn:u32][ct_len:u32][ct]
+[sender_id_len:u16][sender_id][v=4][session_id:16][dh_pub:32][msg_num:u32][pn:u32][kem_ct_len:u16][kem_ct][ct_len:u32][ct]
 ```
 
 Where:
@@ -181,13 +182,15 @@ Where:
 - `dh_pub` is the sender’s current ratchet DH public key.
 - `msg_num` is the message number in the current sending chain.
 - `pn` is the previous chain length (Double Ratchet “PN”), used for skipped-key recovery across DH transitions.
-- `ct` is AES-256-GCM ciphertext+tag, with AAD binding `(sender_id, receiver_id, topic, session_id, dh_pub, msg_num, pn)`.
+- `kem_ct` is an (optional) Kyber ciphertext carried on DH transitions (and for a small carry window) to enable the hybrid DH+KEM root update.
+- `ct` is AES-256-GCM ciphertext+tag, with AAD binding `(sender_id, receiver_id, topic, session_id, dh_pub, msg_num, pn, kem_ct)`.
 
 ### Operational notes (availability vs security)
 
 - The responder derives its send chain only after processing the first inbound DH ratchet step; the initiator should send first.
+- On DH transitions, the sender carries the Kyber ciphertext for a small number of subsequent messages to tolerate bounded reordering. Packets that attempt a DH transition without the expected KEM material after the session is established are rejected as downgrade attempts.
 - Long partitions are handled via retained policy/revocation updates and best-effort sync requests (`pqc/policy/sync/v1`, `pqc/revocations/sync/v1`).
-- Session rekey thresholds are driven by fleet policy (`session_rekey_after_msgs`, `session_rekey_after_secs`) and trigger a fresh handshake.
+- Session rekey thresholds are driven by fleet policy (`session_rekey_after_msgs`, `session_rekey_after_secs`) and trigger an in-session sender refresh (new DH sending key + Kyber KEM injection + carried ciphertext) rather than a full control-plane handshake.
 
 ### Anti-Rollback Floors (Sealed Monotonic Counters)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -63,14 +63,15 @@ For the project’s invariant-level security contract, see `SECURITY_INVARIANTS.
 ### MQTT Security
 - Provisioned identity (strict-mode) via signed operational certificates + key announcements bound to peer id/topic.
 - v1 per-message hybrid encryption (Kyber + X25519 → AES-256-GCM) with signature authentication and sliding-window replay protection.
-- v3 forward-secure sessions (authenticated handshake + DH-driven double ratchet) with topic/context binding and bounded out-of-order acceptance.
+- v4 forward-secure sessions (authenticated handshake + hybrid DH+KEM double ratchet) with topic/context binding, bounded out-of-order acceptance, and in-session PQC refresh.
 - Partition-aware policy + revocation updates (CA-signed, monotonic, retained) with fail-closed gates for high-risk operations.
 - Asymmetric-cost DoS containment: size limits + peer-id sanitation + per-peer/global token-bucket budgets before expensive crypto.
 
 ### CoAP Security
 - Signed payload mode: authenticity-only of application payloads when peer keys are pinned.
 - Custom secure session mode: confidentiality + integrity + anti-replay at the application layer (not OSCORE/DTLS).
-- For interoperability/compliance-critical deployments, OSCORE (with EDHOC) or DTLS is still the “industrial” transport/security boundary.
+- OSCORE mode (RFC 8613): standards-aligned message protection (feature `coap-oscore`).
+- For interoperability/compliance-critical deployments, OSCORE with a standard AKE (e.g., EDHOC) or DTLS is the “industrial” transport/security boundary.
 
 ## Implementation Security
 

--- a/src/coap_secure.rs
+++ b/src/coap_secure.rs
@@ -25,6 +25,28 @@ mod std_client {
         Aes256Gcm, Nonce,
     };
 
+    #[cfg(feature = "coap-oscore")]
+    use coap_message::{MessageOption as _, MinimalWritableMessage as _, ReadableMessage as _};
+    #[cfg(feature = "coap-oscore")]
+    use coap_message_implementations::inmemory_write::Message as InMemoryWriteMessage;
+    #[cfg(feature = "coap-oscore")]
+    use liboscore::{
+        AeadAlg as OscoreAeadAlg, HkdfAlg as OscoreHkdfAlg, OscoreOption, PrimitiveContext,
+        PrimitiveImmutables,
+    };
+
+    // libOSCORE's native C core expects a freestanding `assert(bool)` symbol (declared in
+    // `oscore_native/platform.h`). On most platforms `assert` is only a macro, so there is no
+    // linkable function symbol. For critical IIoT environments, any invariant violation is a
+    // fail-stop condition.
+    #[cfg(feature = "coap-oscore")]
+    #[no_mangle]
+    extern "C" fn assert(expression: bool) {
+        if !expression {
+            std::process::abort();
+        }
+    }
+
     const COAP_SESSION_INIT_PATH: &str = "pqc/session/init";
     const COAP_SESSION_VERSION_V1: u8 = 1;
     const COAP_MAX_SESSION_CONTROL_BYTES: usize = 64 * 1024;
@@ -280,6 +302,280 @@ mod std_client {
             return Err(Error::SignatureVerification("Verification failed".into()));
         }
         Ok(message.to_vec())
+    }
+
+    // --- OSCORE (RFC 8613) backend (feature-gated) ---
+
+    /// OSCORE (RFC 8613) configuration for a single sender/recipient direction.
+    ///
+    /// This struct intentionally focuses on the *transport security context* only. How the
+    /// `master_secret/master_salt` are provisioned is out of scope here:
+    /// - industrial: EDHOC (RFC 9528) or ACE-OSCORE
+    /// - fleet: provisioned PSKs via enrollment
+    ///
+    /// Security note:
+    /// `PrimitiveContext::new_from_fresh_material` requires that the input key material has not
+    /// been used before. For PSK deployments, ensure `context_id` and `sender_id` are unique per
+    /// logical security context and that sequence numbers are not reset across reboots when the
+    /// peer would still accept old sequence numbers.
+    #[cfg(feature = "coap-oscore")]
+    #[derive(Debug, Clone)]
+    pub struct OscoreConfig {
+        /// Master secret / IKM used to derive the OSCORE context.
+        pub master_secret: Vec<u8>,
+        /// Master salt used to derive the OSCORE context (often empty).
+        pub master_salt: Vec<u8>,
+        /// Optional context identifier (kid context).
+        pub context_id: Option<Vec<u8>>,
+        /// Sender ID (KID) for this endpoint.
+        pub sender_id: Vec<u8>,
+        /// Recipient ID (KID) for the peer.
+        pub recipient_id: Vec<u8>,
+        /// HKDF algorithm number (liboscore uses underlying HMAC ids; 5 == HMAC-256/256).
+        pub hkdf_alg: i32,
+        /// AEAD algorithm number (COSE id; eg. 10 == AES-CCM-16-64-128).
+        pub aead_alg: i32,
+    }
+
+    #[cfg(feature = "coap-oscore")]
+    impl OscoreConfig {
+        /// Construct a PSK-based OSCORE config with conservative defaults:
+        /// - HKDF: HMAC-256/256 (5)
+        /// - AEAD: AES-CCM-16-64-128 (10)
+        pub fn psk(master_secret: Vec<u8>, sender_id: Vec<u8>, recipient_id: Vec<u8>) -> Self {
+            Self {
+                master_secret,
+                master_salt: Vec::new(),
+                context_id: None,
+                sender_id,
+                recipient_id,
+                hkdf_alg: 5,
+                aead_alg: 10,
+            }
+        }
+    }
+
+    #[cfg(feature = "coap-oscore")]
+    fn oscore_context_from_config(cfg: &OscoreConfig) -> Result<PrimitiveContext> {
+        let hkdf_alg = OscoreHkdfAlg::from_number(cfg.hkdf_alg)
+            .map_err(|_| Error::InvalidInput("Unsupported OSCORE HKDF algorithm".into()))?;
+        let aead_alg = OscoreAeadAlg::from_number(cfg.aead_alg)
+            .map_err(|_| Error::InvalidInput("Unsupported OSCORE AEAD algorithm".into()))?;
+
+        let imm = PrimitiveImmutables::derive(
+            hkdf_alg,
+            &cfg.master_secret,
+            &cfg.master_salt,
+            cfg.context_id.as_deref(),
+            aead_alg,
+            &cfg.sender_id,
+            &cfg.recipient_id,
+        )
+        .map_err(|_| Error::InvalidInput("Invalid OSCORE context parameters".into()))?;
+
+        Ok(PrimitiveContext::new_from_fresh_material(imm))
+    }
+
+    /// OSCORE-protected CoAP client (RFC 8613).
+    ///
+    /// This is the "industrial" security backend for CoAP:
+    /// - confidentiality + integrity on CoAP options/payload
+    /// - replay protection via OSCORE sequence numbers + replay window
+    ///
+    /// Key exchange / provisioning is intentionally out-of-scope; supply the derived context via
+    /// `OscoreConfig` (PSK or EDHOC-derived).
+    #[cfg(feature = "coap-oscore")]
+    pub struct SecureCoapOscoreClient {
+        ctx: PrimitiveContext,
+        timeout: Duration,
+        socket: Option<UdpSocket>,
+    }
+
+    #[cfg(feature = "coap-oscore")]
+    impl SecureCoapOscoreClient {
+        /// Create a new OSCORE client.
+        pub fn new(cfg: OscoreConfig) -> Result<Self> {
+            Ok(Self {
+                ctx: oscore_context_from_config(&cfg)?,
+                timeout: Duration::from_secs(2),
+                socket: None,
+            })
+        }
+
+        /// Set socket timeout.
+        pub fn with_timeout(mut self, timeout: Duration) -> Self {
+            self.timeout = timeout;
+            self
+        }
+
+        fn ensure_socket(&mut self) -> Result<UdpSocket> {
+            if self.socket.is_none() {
+                let socket =
+                    UdpSocket::bind("0.0.0.0:0").map_err(|e| Error::ClientError(e.to_string()))?;
+                socket
+                    .set_read_timeout(Some(self.timeout))
+                    .map_err(|e| Error::ClientError(e.to_string()))?;
+                self.socket = Some(socket);
+            }
+            self.socket
+                .as_ref()
+                .ok_or_else(|| Error::ClientError("Socket missing".into()))?
+                .try_clone()
+                .map_err(|e| Error::ClientError(e.to_string()))
+        }
+
+        fn protect_packet(
+            &mut self,
+            packet: &Packet,
+        ) -> Result<(Packet, liboscore::raw::oscore_requestid_t)> {
+            // Use an inmemory_write::Message as an ephemeral backend for liboscore. We avoid
+            // leaking any OSCORE internal message representation into the public API.
+            let mut out_code: u8 = u8::from(packet.header.code);
+            let mut tail = vec![0u8; COAP_MAX_SECURE_PAYLOAD_BYTES];
+            let mut msg = InMemoryWriteMessage::new(&mut out_code, &mut tail);
+
+            let (request_id, write_res) =
+                liboscore::protect_request(&mut msg, &mut self.ctx, |pm| {
+                    pm.set_code(u8::from(packet.header.code));
+
+                    for (number, values) in packet.options() {
+                        for v in values.iter() {
+                            pm.add_option(*number, v).map_err(|_| {
+                                Error::CryptoError("OSCORE add_option failed".into())
+                            })?;
+                        }
+                    }
+                    pm.set_payload(&packet.payload)
+                        .map_err(|_| Error::CryptoError("OSCORE set_payload failed".into()))?;
+                    Ok::<(), Error>(())
+                })
+                .map_err(|_| Error::CryptoError("OSCORE protect_request failed".into()))?;
+            write_res?;
+
+            let mut out = Packet::new();
+            out.header = coap_lite::Header::from_raw(&packet.header.to_raw());
+            out.set_token(packet.get_token().to_vec());
+            out.payload = msg.payload().to_vec();
+            out.header.code = coap_lite::MessageClass::from(msg.code());
+
+            for opt in msg.options() {
+                out.add_option(CoapOption::from(opt.number()), opt.value().to_vec());
+            }
+
+            Ok((out, request_id))
+        }
+
+        fn unprotect_response(
+            &mut self,
+            protected: &Packet,
+            correlation: &mut liboscore::raw::oscore_requestid_t,
+        ) -> Result<Packet> {
+            let oscore_opt = protected
+                .get_first_option(CoapOption::Oscore)
+                .ok_or_else(|| Error::ProtocolError("Missing OSCORE option".into()))?;
+            let parsed = OscoreOption::parse(oscore_opt)
+                .map_err(|_| Error::ProtocolError("Unsupported OSCORE option fields".into()))?;
+
+            // Encode the protected message into an inmemory_write::Message backend.
+            let mut code: u8 = u8::from(protected.header.code);
+            let mut tail = vec![0u8; COAP_MAX_SECURE_PAYLOAD_BYTES];
+            let mut msg = InMemoryWriteMessage::new(&mut code, &mut tail);
+            for (number, values) in protected.options() {
+                for v in values.iter() {
+                    msg.add_option(*number, v)
+                        .map_err(|_| Error::CryptoError("OSCORE add_option failed".into()))?;
+                }
+            }
+            msg.set_payload(&protected.payload)
+                .map_err(|_| Error::CryptoError("OSCORE set_payload failed".into()))?;
+
+            let (plain_code, plain_opts, plain_payload) =
+                liboscore::unprotect_response(&mut msg, &mut self.ctx, parsed, correlation, |pm| {
+                    let code = pm.code();
+                    let mut opts = Vec::new();
+                    for o in pm.options() {
+                        opts.push((o.number(), o.value().to_vec()));
+                    }
+                    (code, opts, pm.payload().to_vec())
+                })
+                .map_err(|_| Error::CryptoError("OSCORE unprotect_response failed".into()))?;
+
+            let mut out = Packet::new();
+            out.header = coap_lite::Header::from_raw(&protected.header.to_raw());
+            out.set_token(protected.get_token().to_vec());
+            out.header.code = coap_lite::MessageClass::from(plain_code);
+            out.payload = plain_payload;
+            for (n, v) in plain_opts {
+                out.add_option(CoapOption::from(n), v);
+            }
+            Ok(out)
+        }
+
+        fn send_oscore_request(
+            &mut self,
+            method: RequestType,
+            server: SocketAddr,
+            path: &str,
+            payload: &[u8],
+        ) -> Result<CoapResponse> {
+            // Build a plaintext CoAP request (coap-lite handles options like Uri-Path).
+            let mut request: CoapRequest<()> = CoapRequest::new();
+            request.set_method(method);
+            request.set_path(path);
+            request.message.payload = payload.to_vec();
+
+            // OSCORE protection (creates ciphertext + OSCORE option, and updates sequence state).
+            let (protected, mut correlation) = self.protect_packet(&request.message)?;
+            let packet_bytes = protected
+                .to_bytes()
+                .map_err(|_| Error::ClientError("Packet serialization failed".into()))?;
+
+            let socket = self.ensure_socket()?;
+            socket
+                .send_to(&packet_bytes, server)
+                .map_err(|e| Error::ClientError(e.to_string()))?;
+
+            let mut buf = vec![0u8; 2048];
+            let (amt, _src) = socket
+                .recv_from(&mut buf)
+                .map_err(|e| Error::ClientError(e.to_string()))?;
+
+            let packet = Packet::from_bytes(&buf[..amt])
+                .map_err(|_| Error::ClientError("Invalid packet".into()))?;
+
+            let plain = self.unprotect_response(&packet, &mut correlation)?;
+            Ok(CoapResponse { message: plain })
+        }
+
+        /// Sends a GET request.
+        pub fn get(&mut self, server: SocketAddr, resource: &str) -> Result<CoapResponse> {
+            self.send_oscore_request(RequestType::Get, server, resource, &[])
+        }
+
+        /// Sends a POST request.
+        pub fn post(
+            &mut self,
+            server: SocketAddr,
+            resource: &str,
+            payload: &[u8],
+        ) -> Result<CoapResponse> {
+            self.send_oscore_request(RequestType::Post, server, resource, payload)
+        }
+
+        /// Sends a PUT request.
+        pub fn put(
+            &mut self,
+            server: SocketAddr,
+            resource: &str,
+            payload: &[u8],
+        ) -> Result<CoapResponse> {
+            self.send_oscore_request(RequestType::Put, server, resource, payload)
+        }
+
+        /// Sends a DELETE request.
+        pub fn delete(&mut self, server: SocketAddr, resource: &str) -> Result<CoapResponse> {
+            self.send_oscore_request(RequestType::Delete, server, resource, &[])
+        }
     }
 
     const COAP_SESSION_MAX_SKIPPED_KEYS: usize = 50;
@@ -1702,6 +1998,89 @@ mod std_client {
                 .unwrap();
             assert_eq!(response.message.payload, b"hello-secure");
         }
+
+        #[cfg(feature = "coap-oscore")]
+        #[test]
+        fn coap_oscore_roundtrip_echo() {
+            let server_socket = UdpSocket::bind("127.0.0.1:0").unwrap();
+            server_socket
+                .set_read_timeout(Some(Duration::from_millis(500)))
+                .unwrap();
+            let server_addr = server_socket.local_addr().unwrap();
+
+            let master_secret = vec![0x42u8; 32];
+            let mut client_cfg =
+                OscoreConfig::psk(master_secret.clone(), b"c".to_vec(), b"s".to_vec());
+            client_cfg.context_id = Some(b"ctx1".to_vec());
+            let mut server_cfg = OscoreConfig::psk(master_secret, b"s".to_vec(), b"c".to_vec());
+            server_cfg.context_id = Some(b"ctx1".to_vec());
+
+            thread::spawn(move || {
+                let mut server_ctx = oscore_context_from_config(&server_cfg).unwrap();
+                let mut buf = [0u8; 2048];
+                if let Ok((amt, src)) = server_socket.recv_from(&mut buf) {
+                    let packet = Packet::from_bytes(&buf[..amt]).unwrap();
+
+                    let oscore_opt = packet.get_first_option(CoapOption::Oscore).unwrap();
+                    let parsed = OscoreOption::parse(oscore_opt).unwrap();
+
+                    let mut code: u8 = u8::from(packet.header.code);
+                    let mut tail = vec![0u8; COAP_MAX_SECURE_PAYLOAD_BYTES];
+                    let mut msg = InMemoryWriteMessage::new(&mut code, &mut tail);
+                    for (number, values) in packet.options() {
+                        for v in values.iter() {
+                            msg.add_option(*number, v).unwrap();
+                        }
+                    }
+                    msg.set_payload(&packet.payload).unwrap();
+
+                    let (mut request_id, plaintext) =
+                        liboscore::unprotect_request(&mut msg, parsed, &mut server_ctx, |pm| {
+                            pm.payload().to_vec()
+                        })
+                        .unwrap();
+
+                    // Echo response.
+                    let mut resp_code: u8 = 0;
+                    let mut resp_tail = vec![0u8; COAP_MAX_SECURE_PAYLOAD_BYTES];
+                    let mut resp_msg = InMemoryWriteMessage::new(&mut resp_code, &mut resp_tail);
+
+                    let write_res = liboscore::protect_response(
+                        &mut resp_msg,
+                        &mut server_ctx,
+                        &mut request_id,
+                        |pm| {
+                            pm.set_code(0x45); // 2.05 Content
+                            pm.set_payload(&plaintext)
+                                .map_err(|_| Error::CryptoError("OSCORE set_payload failed".into()))
+                        },
+                    )
+                    .unwrap();
+                    write_res.unwrap();
+
+                    let mut response = Packet::new();
+                    response.header = coap_lite::Header::from_raw(&packet.header.to_raw());
+                    response
+                        .header
+                        .set_type(coap_lite::MessageType::Acknowledgement);
+                    response.set_token(packet.get_token().to_vec());
+                    response.header.code = coap_lite::MessageClass::from(resp_msg.code());
+                    response.payload = resp_msg.payload().to_vec();
+                    for o in resp_msg.options() {
+                        response.add_option(CoapOption::from(o.number()), o.value().to_vec());
+                    }
+
+                    let bytes = response.to_bytes().unwrap();
+                    let _ = server_socket.send_to(&bytes, src);
+                }
+            });
+
+            let mut client = SecureCoapOscoreClient::new(client_cfg).unwrap();
+            let response = client
+                .post(server_addr, "oscore/echo", b"hello-oscore")
+                .unwrap();
+            assert_eq!(response.message.payload, b"hello-oscore");
+        }
     }
 }
 
@@ -1709,6 +2088,9 @@ mod std_client {
 pub use std_client::{
     AclRules, DtlsConfig, SecureCoapClient, SecureCoapSessionClient, SecureCoapSessionServer,
 };
+
+#[cfg(all(feature = "coap-std", feature = "coap-oscore"))]
+pub use std_client::{OscoreConfig, SecureCoapOscoreClient};
 
 #[cfg(not(feature = "coap-std"))]
 mod nostd_core {

--- a/src/mqtt_secure.rs
+++ b/src/mqtt_secure.rs
@@ -272,7 +272,7 @@ pub struct SecureMqttClient {
     storage_id: String,
     sequence_number: u64,
     strict_mode: bool,
-    /// If true, disallow v1 per-message hybrid encryption and require forward-secure sessions (v3, double ratchet).
+    /// If true, disallow v1 per-message hybrid encryption and require forward-secure sessions (v4, hybrid DH+KEM double ratchet).
     require_sessions: bool,
     /// If true, require rollback-resistant sealing/storage in the active fleet policy.
     require_rollback_resistant_storage: bool,
@@ -659,6 +659,11 @@ fn derive_session_root_key_v3(kem_ss: &[u8], dh_ss: &[u8]) -> Result<[u8; 32]> {
     Ok(rk0)
 }
 
+const MQTT_SESSION_PACKET_VERSION_V3: u8 = 3;
+const MQTT_SESSION_PACKET_VERSION_V4: u8 = 4;
+const MQTT_SESSION_KEM_CT_CARRY_MESSAGES: u8 = 3;
+const MQTT_SESSION_MAX_KEM_CIPHERTEXT_BYTES: usize = 2048;
+
 const MQTT_SESSION_MAX_SKIPPED_KEYS: usize = 50;
 const MQTT_SESSION_MAX_MESSAGES: u32 = 100_000;
 const MQTT_SESSION_SKIPPED_KEYS_TOTAL_LIMIT: usize = 4 * MQTT_SESSION_MAX_SKIPPED_KEYS;
@@ -676,9 +681,23 @@ struct SessionPacketHeaderV3 {
     prev_chain_len: u32,
 }
 
+#[derive(Debug, Clone)]
+struct SessionPacketHeaderV4 {
+    dh_pub: [u8; 32],
+    msg_num: u32,
+    prev_chain_len: u32,
+    kem_ciphertext: Vec<u8>,
+}
+
+#[derive(Debug, Default)]
+struct SessionRatchetKemMaterial {
+    kem_ss_in: Option<[u8; 32]>,
+    kem_ss_out: Option<[u8; 32]>,
+    kem_ct_out: Option<Vec<u8>>,
+}
+
 struct MqttSession {
     session_id: [u8; 16],
-    created_at: Instant,
     // DH-driven double ratchet state (PCS).
     root_key: [u8; 32],
     dh_send_sk: X25519StaticSecret,
@@ -693,6 +712,12 @@ struct MqttSession {
     prev_chain_len: u32,
     // Monotonic send counter for policy rekey thresholds (not a cryptographic nonce/input).
     sent_messages_total: u32,
+    // Carry the KEM ciphertext for a few messages after a send-chain rotation.
+    send_kem_ciphertext: Option<Vec<u8>>,
+    send_kem_ciphertext_uses_remaining: u8,
+    // PCS refresh tracking (to avoid refreshing on every message once thresholds are crossed).
+    last_pcs_refresh_total: u32,
+    last_pcs_refresh_at: Instant,
     // Out-of-order / late delivery support across DH chain transitions.
     skipped_message_keys: std::collections::HashMap<SkippedKeyId, [u8; 32]>,
 }
@@ -703,6 +728,7 @@ impl MqttSession {
         rk0: [u8; 32],
         peer_handshake_dh: [u8; 32],
     ) -> Result<Self> {
+        let now = Instant::now();
         // Initiator starts with a fresh DH sending key to force an early DH-ratchet step on the responder.
         let dh_send_sk = X25519StaticSecret::random_from_rng(OsRng);
         let dh_send_pk = X25519PublicKey::from(&dh_send_sk).to_bytes();
@@ -710,7 +736,6 @@ impl MqttSession {
 
         Ok(Self {
             session_id,
-            created_at: Instant::now(),
             root_key,
             dh_send_sk,
             dh_send_pk,
@@ -721,6 +746,10 @@ impl MqttSession {
             recv_msg_num: 0,
             prev_chain_len: 0,
             sent_messages_total: 0,
+            send_kem_ciphertext: None,
+            send_kem_ciphertext_uses_remaining: 0,
+            last_pcs_refresh_total: 0,
+            last_pcs_refresh_at: now,
             skipped_message_keys: std::collections::HashMap::new(),
         })
     }
@@ -732,11 +761,11 @@ impl MqttSession {
         responder_handshake_pk: [u8; 32],
         initiator_handshake_pk: [u8; 32],
     ) -> Self {
+        let now = Instant::now();
         // Responder cannot derive a receive chain until it sees the initiator's first ratchet DH key.
         // It keeps its handshake DH key as DHs, so it can ratchet immediately on the first message.
         Self {
             session_id,
-            created_at: Instant::now(),
             root_key: rk0,
             dh_send_sk: responder_handshake_sk,
             dh_send_pk: responder_handshake_pk,
@@ -747,6 +776,10 @@ impl MqttSession {
             recv_msg_num: 0,
             prev_chain_len: 0,
             sent_messages_total: 0,
+            send_kem_ciphertext: None,
+            send_kem_ciphertext_uses_remaining: 0,
+            last_pcs_refresh_total: 0,
+            last_pcs_refresh_at: now,
             skipped_message_keys: std::collections::HashMap::new(),
         }
     }
@@ -781,6 +814,134 @@ impl MqttSession {
         Ok((new_rk, ck))
     }
 
+    fn kdf_rk_hybrid(
+        rk: &[u8; 32],
+        dh_send_sk: &X25519StaticSecret,
+        dh_recv_pk: &[u8; 32],
+        kem_ss: Option<&[u8; 32]>,
+    ) -> Result<([u8; 32], [u8; 32])> {
+        let Some(kem_ss) = kem_ss else {
+            return Self::kdf_rk(rk, dh_send_sk, dh_recv_pk);
+        };
+
+        let peer_pub = X25519PublicKey::from(*dh_recv_pk);
+        let mut dh_out = dh_send_sk.diffie_hellman(&peer_pub).to_bytes();
+
+        let mut ikm = [0u8; 32 + 32];
+        ikm[..32].copy_from_slice(&dh_out);
+        ikm[32..].copy_from_slice(kem_ss);
+
+        // Domain separation: hybrid ratchet (DH + KEM) uses a distinct label namespace.
+        let (_, hkdf) = Hkdf::<Sha256>::extract(Some(rk), &ikm);
+        let mut new_rk = [0u8; 32];
+        let mut ck = [0u8; 32];
+        hkdf.expand(b"pqc-iiot:mqtt-session:v4:rk", &mut new_rk)
+            .map_err(|_| Error::CryptoError("HKDF expand failed (rk v4)".into()))?;
+        hkdf.expand(b"pqc-iiot:mqtt-session:v4:ck", &mut ck)
+            .map_err(|_| Error::CryptoError("HKDF expand failed (ck v4)".into()))?;
+
+        dh_out.zeroize();
+        ikm.zeroize();
+        Ok((new_rk, ck))
+    }
+
+    fn set_send_kem_ciphertext(&mut self, kem_ciphertext: Vec<u8>) {
+        self.send_kem_ciphertext = Some(kem_ciphertext);
+        self.send_kem_ciphertext_uses_remaining = MQTT_SESSION_KEM_CT_CARRY_MESSAGES;
+    }
+
+    fn kem_ciphertext_for_header(&mut self) -> Vec<u8> {
+        if self.send_kem_ciphertext_uses_remaining == 0 {
+            return Vec::new();
+        }
+        let ct = self.send_kem_ciphertext.clone().unwrap_or_default();
+        self.send_kem_ciphertext_uses_remaining =
+            self.send_kem_ciphertext_uses_remaining.saturating_sub(1);
+        if self.send_kem_ciphertext_uses_remaining == 0 {
+            self.send_kem_ciphertext = None;
+        }
+        ct
+    }
+
+    fn should_pcs_refresh(
+        &self,
+        refresh_after_msgs: Option<u32>,
+        refresh_after_secs: Option<u64>,
+    ) -> bool {
+        let mut required = false;
+        if let Some(max_msgs) = refresh_after_msgs {
+            if self
+                .sent_messages_total
+                .saturating_sub(self.last_pcs_refresh_total)
+                >= max_msgs
+            {
+                required = true;
+            }
+        }
+        if let Some(max_secs) = refresh_after_secs {
+            if self.last_pcs_refresh_at.elapsed() >= Duration::from_secs(max_secs) {
+                required = true;
+            }
+        }
+        required
+    }
+
+    fn mark_pcs_refreshed(&mut self) {
+        self.last_pcs_refresh_total = self.sent_messages_total;
+        self.last_pcs_refresh_at = Instant::now();
+    }
+
+    fn rotate_send_chain_with_kem(
+        &mut self,
+        kem_ss_out: Option<[u8; 32]>,
+        kem_ct_out: Option<Vec<u8>>,
+    ) -> Result<()> {
+        self.prev_chain_len = self.send_msg_num;
+        self.send_msg_num = 0;
+
+        self.dh_send_sk = X25519StaticSecret::random_from_rng(OsRng);
+        self.dh_send_pk = X25519PublicKey::from(&self.dh_send_sk).to_bytes();
+        let (rk2, send_ck) = Self::kdf_rk_hybrid(
+            &self.root_key,
+            &self.dh_send_sk,
+            &self.dh_recv_pk,
+            kem_ss_out.as_ref(),
+        )?;
+        self.root_key = rk2;
+        self.send_chain_key = Some(send_ck);
+        if let Some(ct) = kem_ct_out {
+            self.set_send_kem_ciphertext(ct);
+        } else {
+            self.send_kem_ciphertext = None;
+            self.send_kem_ciphertext_uses_remaining = 0;
+        }
+        Ok(())
+    }
+
+    fn dh_ratchet_with_kem(
+        &mut self,
+        new_peer_dh: [u8; 32],
+        kem_ss_in: Option<[u8; 32]>,
+        kem_ss_out: Option<[u8; 32]>,
+        kem_ct_out: Option<Vec<u8>>,
+    ) -> Result<()> {
+        // Step 1: update receiving chain.
+        self.dh_recv_pk = new_peer_dh;
+        let (rk1, recv_ck) = Self::kdf_rk_hybrid(
+            &self.root_key,
+            &self.dh_send_sk,
+            &self.dh_recv_pk,
+            kem_ss_in.as_ref(),
+        )?;
+        self.root_key = rk1;
+        self.recv_chain_key = Some(recv_ck);
+        self.recv_msg_num = 0;
+
+        // Step 2: rotate DHs and derive sending chain.
+        self.rotate_send_chain_with_kem(kem_ss_out, kem_ct_out)?;
+        Ok(())
+    }
+
     fn aad_v3(
         sender_id: &str,
         receiver_id: &str,
@@ -800,6 +961,30 @@ impl MqttSession {
         aad.extend_from_slice(&header.dh_pub);
         aad.extend_from_slice(&header.msg_num.to_be_bytes());
         aad.extend_from_slice(&header.prev_chain_len.to_be_bytes());
+        aad
+    }
+
+    fn aad_v4(
+        sender_id: &str,
+        receiver_id: &str,
+        topic: &str,
+        session_id: &[u8; 16],
+        header: &SessionPacketHeaderV4,
+    ) -> Vec<u8> {
+        let mut aad = Vec::new();
+        aad.extend_from_slice(b"pqc-iiot:mqtt-msg:v4");
+        aad.extend_from_slice(&(sender_id.len() as u16).to_be_bytes());
+        aad.extend_from_slice(sender_id.as_bytes());
+        aad.extend_from_slice(&(receiver_id.len() as u16).to_be_bytes());
+        aad.extend_from_slice(receiver_id.as_bytes());
+        aad.extend_from_slice(&(topic.len() as u16).to_be_bytes());
+        aad.extend_from_slice(topic.as_bytes());
+        aad.extend_from_slice(session_id);
+        aad.extend_from_slice(&header.dh_pub);
+        aad.extend_from_slice(&header.msg_num.to_be_bytes());
+        aad.extend_from_slice(&header.prev_chain_len.to_be_bytes());
+        aad.extend_from_slice(&(header.kem_ciphertext.len() as u16).to_be_bytes());
+        aad.extend_from_slice(&header.kem_ciphertext);
         aad
     }
 
@@ -870,55 +1055,6 @@ impl MqttSession {
         self.root_key = rk2;
         self.send_chain_key = Some(send_ck);
         Ok(())
-    }
-
-    fn encrypt_v3(
-        &mut self,
-        sender_id: &str,
-        receiver_id: &str,
-        topic: &str,
-        plaintext: &[u8],
-    ) -> Result<(SessionPacketHeaderV3, Vec<u8>)> {
-        if self.sent_messages_total >= MQTT_SESSION_MAX_MESSAGES {
-            return Err(Error::ProtocolError(format!(
-                "Session {} exhausted message budget (send)",
-                hex::encode(self.session_id)
-            )));
-        }
-
-        let Some(ck) = self.send_chain_key else {
-            return Err(Error::ProtocolError(
-                "Session send chain not ready (await first inbound ratchet)".into(),
-            ));
-        };
-
-        let (next_ck, mk) = Self::kdf_ck(&ck)?;
-        self.send_chain_key = Some(next_ck);
-        let msg_num = self.send_msg_num;
-        self.send_msg_num = self.send_msg_num.saturating_add(1);
-        self.sent_messages_total = self.sent_messages_total.saturating_add(1);
-
-        let header = SessionPacketHeaderV3 {
-            dh_pub: self.dh_send_pk,
-            msg_num,
-            prev_chain_len: self.prev_chain_len,
-        };
-
-        let aad = Self::aad_v3(sender_id, receiver_id, topic, &self.session_id, &header);
-        let nonce_bytes = Self::nonce_v3(&self.session_id, msg_num);
-
-        let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&mk));
-        let ciphertext = cipher
-            .encrypt(
-                Nonce::from_slice(&nonce_bytes),
-                Payload {
-                    msg: plaintext,
-                    aad: &aad,
-                },
-            )
-            .map_err(|_| Error::CryptoError("AES-GCM encryption failed".into()))?;
-
-        Ok((header, ciphertext))
     }
 
     fn decrypt_with_mk_v3(
@@ -1002,6 +1138,161 @@ impl MqttSession {
         self.recv_chain_key = Some(ck);
 
         self.decrypt_with_mk_v3(sender_id, receiver_id, topic, &header, &mk, ciphertext)
+    }
+
+    fn encrypt_v4(
+        &mut self,
+        sender_id: &str,
+        receiver_id: &str,
+        topic: &str,
+        plaintext: &[u8],
+    ) -> Result<(SessionPacketHeaderV4, Vec<u8>)> {
+        if self.sent_messages_total >= MQTT_SESSION_MAX_MESSAGES {
+            return Err(Error::ProtocolError(format!(
+                "Session {} exhausted message budget (send)",
+                hex::encode(self.session_id)
+            )));
+        }
+
+        let Some(ck) = self.send_chain_key else {
+            return Err(Error::ProtocolError(
+                "Session send chain not ready (await first inbound ratchet)".into(),
+            ));
+        };
+
+        let kem_ciphertext = self.kem_ciphertext_for_header();
+        if kem_ciphertext.len() > MQTT_SESSION_MAX_KEM_CIPHERTEXT_BYTES {
+            return Err(Error::ProtocolError(format!(
+                "Session KEM ciphertext too large: {} bytes",
+                kem_ciphertext.len()
+            )));
+        }
+
+        let (next_ck, mk) = Self::kdf_ck(&ck)?;
+        self.send_chain_key = Some(next_ck);
+        let msg_num = self.send_msg_num;
+        self.send_msg_num = self.send_msg_num.saturating_add(1);
+        self.sent_messages_total = self.sent_messages_total.saturating_add(1);
+
+        let header = SessionPacketHeaderV4 {
+            dh_pub: self.dh_send_pk,
+            msg_num,
+            prev_chain_len: self.prev_chain_len,
+            kem_ciphertext,
+        };
+
+        let aad = Self::aad_v4(sender_id, receiver_id, topic, &self.session_id, &header);
+        let nonce_bytes = Self::nonce_v3(&self.session_id, msg_num);
+
+        let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&mk));
+        let ciphertext = cipher
+            .encrypt(
+                Nonce::from_slice(&nonce_bytes),
+                Payload {
+                    msg: plaintext,
+                    aad: &aad,
+                },
+            )
+            .map_err(|_| Error::CryptoError("AES-GCM encryption failed".into()))?;
+
+        Ok((header, ciphertext))
+    }
+
+    fn decrypt_with_mk_v4(
+        &self,
+        sender_id: &str,
+        receiver_id: &str,
+        topic: &str,
+        header: &SessionPacketHeaderV4,
+        mk: &[u8; 32],
+        ciphertext: &[u8],
+    ) -> Result<Vec<u8>> {
+        let aad = Self::aad_v4(sender_id, receiver_id, topic, &self.session_id, header);
+        let nonce_bytes = Self::nonce_v3(&self.session_id, header.msg_num);
+        let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(mk));
+        cipher
+            .decrypt(
+                Nonce::from_slice(&nonce_bytes),
+                Payload {
+                    msg: ciphertext,
+                    aad: &aad,
+                },
+            )
+            .map_err(|_| Error::CryptoError("AES-GCM decryption failed".into()))
+    }
+
+    fn decrypt_v4(
+        &mut self,
+        sender_id: &str,
+        receiver_id: &str,
+        topic: &str,
+        header: SessionPacketHeaderV4,
+        ciphertext: &[u8],
+        ratchet: SessionRatchetKemMaterial,
+    ) -> Result<Vec<u8>> {
+        let SessionRatchetKemMaterial {
+            kem_ss_in,
+            kem_ss_out,
+            kem_ct_out,
+        } = ratchet;
+        if let Some(mk) = self.skipped_message_keys.remove(&SkippedKeyId {
+            dh_pub: header.dh_pub,
+            msg_num: header.msg_num,
+        }) {
+            return self.decrypt_with_mk_v4(
+                sender_id,
+                receiver_id,
+                topic,
+                &header,
+                &mk,
+                ciphertext,
+            );
+        }
+
+        // DH ratchet step: peer rotated its DH sending key.
+        if header.dh_pub != self.dh_recv_pk {
+            self.skip_message_keys(header.prev_chain_len)?;
+
+            // Downgrade resistance: after the session has a receiving chain, require KEM on DH steps.
+            if self.recv_chain_key.is_some() && kem_ss_in.is_none() {
+                return Err(Error::ProtocolError(
+                    "Missing KEM secret on hybrid DH ratchet step".into(),
+                ));
+            }
+
+            self.dh_ratchet_with_kem(header.dh_pub, kem_ss_in, kem_ss_out, kem_ct_out)?;
+        }
+
+        let Some(mut ck) = self.recv_chain_key else {
+            return Err(Error::CryptoError(
+                "Session receive chain not ready (await DH ratchet)".into(),
+            ));
+        };
+
+        if header.msg_num < self.recv_msg_num {
+            return Err(Error::CryptoError("Message too old / replay".into()));
+        }
+
+        let delta = header.msg_num - self.recv_msg_num;
+        if delta > MQTT_SESSION_MAX_SKIPPED_KEYS as u32 {
+            return Err(Error::CryptoError(
+                "Message too far in the future (skip limit exceeded)".into(),
+            ));
+        }
+
+        while self.recv_msg_num < header.msg_num {
+            let (next_ck, mk) = Self::kdf_ck(&ck)?;
+            self.store_skipped_key(self.dh_recv_pk, self.recv_msg_num, mk);
+            ck = next_ck;
+            self.recv_msg_num = self.recv_msg_num.saturating_add(1);
+        }
+
+        let (next_ck, mk) = Self::kdf_ck(&ck)?;
+        ck = next_ck;
+        self.recv_msg_num = self.recv_msg_num.saturating_add(1);
+        self.recv_chain_key = Some(ck);
+
+        self.decrypt_with_mk_v4(sender_id, receiver_id, topic, &header, &mk, ciphertext)
     }
 }
 
@@ -3046,7 +3337,7 @@ impl SecureMqttClient {
         Ok(())
     }
 
-    /// Publish an encrypted message using the forward-secure session ratchet (v3, double ratchet).
+    /// Publish an encrypted message using the forward-secure session ratchet (v4, hybrid DH+KEM double ratchet).
     ///
     /// Requires a session to be established via `initiate_session()` and a corresponding response.
     pub fn publish_encrypted_session(
@@ -3058,46 +3349,6 @@ impl SecureMqttClient {
         self.ensure_connected()?;
         self.ensure_fleet_policy_fresh("publish_encrypted_session")?;
 
-        // Enforce periodic re-handshake thresholds from fleet policy (PCS building block).
-        let needs_rekey = match self.sessions.get(target_peer_id) {
-            Some(peer_sessions) => {
-                let msgs = self.session_rekey_after_msgs;
-                let secs = self.session_rekey_after_secs;
-                let mut required = false;
-                if let Some(max_msgs) = msgs {
-                    if peer_sessions.current.sent_messages_total >= max_msgs {
-                        required = true;
-                    }
-                }
-                if let Some(max_secs) = secs {
-                    if peer_sessions.current.created_at.elapsed() >= Duration::from_secs(max_secs) {
-                        required = true;
-                    }
-                }
-                required
-            }
-            None => {
-                return Err(Error::ClientError(format!(
-                    "No active session for {}; call initiate_session() and wait for response",
-                    target_peer_id
-                )))
-            }
-        };
-        if needs_rekey {
-            if !self
-                .pending_sessions
-                .values()
-                .any(|p| p.peer_id == target_peer_id)
-            {
-                // Best-effort: initiate a fresh session; caller retries once established.
-                self.initiate_session(target_peer_id)?;
-            }
-            return Err(Error::ClientError(format!(
-                "Session requires rekey; initiated session handshake for {}; retry later",
-                target_peer_id
-            )));
-        }
-
         let peer_sessions = self.sessions.get_mut(target_peer_id).ok_or_else(|| {
             Error::ClientError(format!(
                 "No active session for {}; call initiate_session() and wait for response",
@@ -3106,10 +3357,55 @@ impl SecureMqttClient {
         })?;
 
         let session = peer_sessions.current_mut();
-        let (header, ciphertext) =
-            session.encrypt_v3(&self.client_id, target_peer_id, topic, payload)?;
+        // In-session post-compromise recovery (PQC PCS):
+        // periodically rotate the sender DH key and inject a Kyber KEM secret into the root KDF.
+        //
+        // This avoids full session re-handshakes in the common case, and provides PCS even for
+        // unidirectional traffic (telemetry) by allowing the sender to proactively ratchet.
+        if session.should_pcs_refresh(self.session_rekey_after_msgs, self.session_rekey_after_secs)
+        {
+            let peer_keys = self.keystore.get(target_peer_id).ok_or_else(|| {
+                Error::ClientError(format!(
+                    "Cannot refresh session: missing keystore entry for {}",
+                    target_peer_id
+                ))
+            })?;
+            if !peer_keys.is_trusted || peer_keys.kem_pk.is_empty() {
+                return Err(Error::ClientError(format!(
+                    "Cannot refresh session: peer not trusted/ready: {}",
+                    target_peer_id
+                )));
+            }
 
-        // Packet v3 (double ratchet): [sender_id_len:u16][sender_id][v=3][session_id:16][dh_pub:32][msg_num:u32][pn:u32][ct_len:u32][ct]
+            let kyber = kyber_for_pk_len(peer_keys.kem_pk.len())?;
+            let (kem_ct, mut kem_ss) = kyber.encapsulate(&peer_keys.kem_pk)?;
+            if kem_ct.len() > MQTT_SESSION_MAX_KEM_CIPHERTEXT_BYTES {
+                kem_ss.zeroize();
+                return Err(Error::ProtocolError(format!(
+                    "Session KEM ciphertext too large: {} bytes",
+                    kem_ct.len()
+                )));
+            }
+            if kem_ss.len() != 32 {
+                kem_ss.zeroize();
+                return Err(Error::CryptoError(format!(
+                    "Unexpected Kyber shared secret length: {}",
+                    kem_ss.len()
+                )));
+            }
+            let mut kem_ss_arr = [0u8; 32];
+            kem_ss_arr.copy_from_slice(&kem_ss);
+            kem_ss.zeroize();
+
+            session.rotate_send_chain_with_kem(Some(kem_ss_arr), Some(kem_ct))?;
+            session.mark_pcs_refreshed();
+        }
+
+        let (header, ciphertext) =
+            session.encrypt_v4(&self.client_id, target_peer_id, topic, payload)?;
+
+        // Packet v4 (double ratchet + KEM refresh):
+        // [sender_id_len:u16][sender_id][v=4][session_id:16][dh_pub:32][msg_num:u32][pn:u32][kem_ct_len:u16][kem_ct][ct_len:u32][ct]
         let sender_id_bytes = self.client_id.as_bytes();
         let sender_id_len = sender_id_bytes.len() as u16;
 
@@ -3118,16 +3414,32 @@ impl SecureMqttClient {
         }
         let ct_len = ciphertext.len() as u32;
 
+        if header.kem_ciphertext.len() > u16::MAX as usize {
+            return Err(Error::InvalidInput("KEM ciphertext too large".into()));
+        }
+        let kem_ct_len = header.kem_ciphertext.len() as u16;
+
         let mut packet = Vec::with_capacity(
-            2 + sender_id_bytes.len() + 1 + 16 + 32 + 4 + 4 + 4 + ciphertext.len(),
+            2 + sender_id_bytes.len()
+                + 1
+                + 16
+                + 32
+                + 4
+                + 4
+                + 2
+                + header.kem_ciphertext.len()
+                + 4
+                + ciphertext.len(),
         );
         packet.extend_from_slice(&sender_id_len.to_be_bytes());
         packet.extend_from_slice(sender_id_bytes);
-        packet.push(3);
+        packet.push(MQTT_SESSION_PACKET_VERSION_V4);
         packet.extend_from_slice(&session.session_id);
         packet.extend_from_slice(&header.dh_pub);
         packet.extend_from_slice(&header.msg_num.to_be_bytes());
         packet.extend_from_slice(&header.prev_chain_len.to_be_bytes());
+        packet.extend_from_slice(&kem_ct_len.to_be_bytes());
+        packet.extend_from_slice(&header.kem_ciphertext);
         packet.extend_from_slice(&ct_len.to_be_bytes());
         packet.extend_from_slice(&ciphertext);
 
@@ -3412,10 +3724,21 @@ impl SecureMqttClient {
                             return Ok(None);
                         }
                         trace!("mqtt rx extracted sender_id={}", sender_id);
-                        // Session/ratchet encrypted packet (v3, double ratchet):
+                        // Session/ratchet encrypted packet (v4, hybrid double ratchet):
+                        // [4][session_id:16][dh_pub:32][msg_num:u32][pn:u32][kem_ct_len:u16][kem_ct][ct_len:u32][ct]
+                        //
+                        // Legacy (v3, classical double ratchet):
                         // [3][session_id:16][dh_pub:32][msg_num:u32][pn:u32][ct_len:u32][ct]
                         // No per-message signature; authenticity is provided by the established session keys.
-                        if !rest.is_empty() && rest[0] == 3 {
+                        if !rest.is_empty() && rest[0] == MQTT_SESSION_PACKET_VERSION_V4 {
+                            if let Some(plaintext) =
+                                self.try_decrypt_session_packet_v4(&topic, sender_id, rest)?
+                            {
+                                return Ok(Some((topic, plaintext)));
+                            }
+                            return Ok(None);
+                        }
+                        if !rest.is_empty() && rest[0] == MQTT_SESSION_PACKET_VERSION_V3 {
                             if let Some(plaintext) =
                                 self.try_decrypt_session_packet_v3(&topic, sender_id, rest)?
                             {
@@ -4150,6 +4473,244 @@ impl SecureMqttClient {
             Ok(pt) => Ok(Some(pt)),
             Err(e) => {
                 warn!("Session decrypt failed for {}: {}", sender_id, e);
+                self.metrics.inc_decryption_failure();
+                Ok(None)
+            }
+        }
+    }
+
+    fn try_decrypt_session_packet_v4(
+        &mut self,
+        topic: &str,
+        sender_id: &str,
+        rest: &[u8],
+    ) -> Result<Option<Vec<u8>>> {
+        // [4][session_id:16][dh_pub:32][msg_num:u32][pn:u32][kem_ct_len:u16][kem_ct][ct_len:u32][ct]
+        const FIXED_PREFIX_LEN: usize = 1 + 16 + 32 + 4 + 4 + 2;
+        if rest.len() < FIXED_PREFIX_LEN + 4 {
+            warn!(
+                "Dropping session packet v4 from {}: too short ({} bytes)",
+                sender_id,
+                rest.len()
+            );
+            return Ok(None);
+        }
+
+        let mut session_id = [0u8; 16];
+        session_id.copy_from_slice(&rest[1..17]);
+        let mut dh_pub = [0u8; 32];
+        dh_pub.copy_from_slice(&rest[17..49]);
+        let msg_num = u32::from_be_bytes([rest[49], rest[50], rest[51], rest[52]]);
+        let pn = u32::from_be_bytes([rest[53], rest[54], rest[55], rest[56]]);
+        let kem_ct_len = u16::from_be_bytes([rest[57], rest[58]]) as usize;
+
+        if kem_ct_len > MQTT_SESSION_MAX_KEM_CIPHERTEXT_BYTES {
+            warn!(
+                "Dropping session packet v4 from {}: kem_ct_len too large ({})",
+                sender_id, kem_ct_len
+            );
+            return Ok(None);
+        }
+
+        let kem_ct_start: usize = 59;
+        let ct_len_start = kem_ct_start + kem_ct_len;
+        if rest.len() < ct_len_start + 4 {
+            warn!(
+                "Dropping session packet v4 from {}: truncated header",
+                sender_id
+            );
+            return Ok(None);
+        }
+
+        let ct_len = u32::from_be_bytes([
+            rest[ct_len_start],
+            rest[ct_len_start + 1],
+            rest[ct_len_start + 2],
+            rest[ct_len_start + 3],
+        ]) as usize;
+        let header_len = ct_len_start + 4;
+        if rest.len() != header_len + ct_len {
+            warn!(
+                "Dropping session packet v4 from {}: length mismatch kem_ct_len={} ct_len={} total={}",
+                sender_id,
+                kem_ct_len,
+                ct_len,
+                rest.len()
+            );
+            return Ok(None);
+        }
+
+        let kem_ct = &rest[kem_ct_start..kem_ct_start + kem_ct_len];
+        let ciphertext = &rest[header_len..];
+
+        let kem_ciphertext_vec = if kem_ct.is_empty() {
+            Vec::new()
+        } else {
+            kem_ct.to_vec()
+        };
+        let header = SessionPacketHeaderV4 {
+            dh_pub,
+            msg_num,
+            prev_chain_len: pn,
+            kem_ciphertext: kem_ciphertext_vec,
+        };
+
+        let needs_ratchet = match self.sessions.get(sender_id) {
+            Some(peer_sessions) => {
+                if peer_sessions.current.session_id == session_id {
+                    dh_pub != peer_sessions.current.dh_recv_pk
+                } else if let Some((prev, _)) = &peer_sessions.previous {
+                    if prev.session_id == session_id {
+                        dh_pub != prev.dh_recv_pk
+                    } else {
+                        warn!(
+                            "Dropping session packet v4 from {}: session_id mismatch",
+                            sender_id
+                        );
+                        return Ok(None);
+                    }
+                } else {
+                    warn!(
+                        "Dropping session packet v4 from {}: session_id mismatch",
+                        sender_id
+                    );
+                    return Ok(None);
+                }
+            }
+            None => {
+                warn!(
+                    "Dropping session packet v4 from {}: no active session",
+                    sender_id
+                );
+                return Ok(None);
+            }
+        };
+
+        let mut ratchet = SessionRatchetKemMaterial::default();
+
+        if needs_ratchet {
+            // Asymmetric-cost DoS: KEM decapsulation + encapsulation on ratchet steps is expensive.
+            if !self.allow_decrypt(sender_id) {
+                warn!(
+                    "Dropping session packet v4 from {}: rate limited (decrypt budget)",
+                    sender_id
+                );
+                self.metrics.inc_rate_limit_drop();
+                return Ok(None);
+            }
+
+            if !kem_ct.is_empty() {
+                match self.provider.kem_decapsulate(kem_ct) {
+                    Ok(ss) => ratchet.kem_ss_in = Some(ss),
+                    Err(e) => {
+                        warn!(
+                            "Dropping session packet v4 from {}: KEM decapsulation failed: {}",
+                            sender_id, e
+                        );
+                        self.metrics.inc_decryption_failure();
+                        return Ok(None);
+                    }
+                }
+            }
+
+            // Prepare an outbound KEM ciphertext for our own send-chain rotation.
+            let peer_keys = match self.keystore.get(sender_id) {
+                Some(k) => k,
+                None => {
+                    warn!(
+                        "Dropping session packet v4 from {}: missing keystore entry",
+                        sender_id
+                    );
+                    return Ok(None);
+                }
+            };
+            if peer_keys.kem_pk.is_empty() {
+                warn!(
+                    "Dropping session packet v4 from {}: peer KEM pk missing",
+                    sender_id
+                );
+                return Ok(None);
+            }
+            let kyber = match kyber_for_pk_len(peer_keys.kem_pk.len()) {
+                Ok(k) => k,
+                Err(e) => {
+                    warn!(
+                        "Dropping session packet v4 from {}: invalid peer Kyber pk: {}",
+                        sender_id, e
+                    );
+                    return Ok(None);
+                }
+            };
+            let (ct, mut ss_vec) = match kyber.encapsulate(&peer_keys.kem_pk) {
+                Ok(v) => v,
+                Err(e) => {
+                    warn!(
+                        "Dropping session packet v4 from {}: KEM encapsulation failed: {}",
+                        sender_id, e
+                    );
+                    self.metrics.inc_decryption_failure();
+                    return Ok(None);
+                }
+            };
+            if ct.len() > MQTT_SESSION_MAX_KEM_CIPHERTEXT_BYTES {
+                ss_vec.zeroize();
+                warn!(
+                    "Dropping session packet v4 from {}: outbound kem_ct too large ({})",
+                    sender_id,
+                    ct.len()
+                );
+                return Ok(None);
+            }
+            if ss_vec.len() != 32 {
+                ss_vec.zeroize();
+                warn!(
+                    "Dropping session packet v4 from {}: unexpected KEM ss len {}",
+                    sender_id,
+                    ss_vec.len()
+                );
+                return Ok(None);
+            }
+            let mut ss_arr = [0u8; 32];
+            ss_arr.copy_from_slice(&ss_vec);
+            ss_vec.zeroize();
+
+            ratchet.kem_ss_out = Some(ss_arr);
+            ratchet.kem_ct_out = Some(ct);
+        }
+
+        let peer_sessions = match self.sessions.get_mut(sender_id) {
+            Some(s) => s,
+            None => {
+                warn!(
+                    "Dropping session packet v4 from {}: no active session",
+                    sender_id
+                );
+                return Ok(None);
+            }
+        };
+
+        let session = match peer_sessions.get_mut_by_session_id(&session_id) {
+            Some(s) => s,
+            None => {
+                warn!(
+                    "Dropping session packet v4 from {}: session_id mismatch",
+                    sender_id
+                );
+                return Ok(None);
+            }
+        };
+
+        match session.decrypt_v4(
+            sender_id,
+            &self.client_id,
+            topic,
+            header,
+            ciphertext,
+            ratchet,
+        ) {
+            Ok(pt) => Ok(Some(pt)),
+            Err(e) => {
+                warn!("Session decrypt v4 failed for {}: {}", sender_id, e);
                 self.metrics.inc_decryption_failure();
                 Ok(None)
             }

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -17,6 +17,8 @@ pub mod policy;
 pub mod provider;
 /// Signed revocation updates (CA-distributed).
 pub mod revocation;
+/// Root-of-trust boundary (TPM/TEE/HSM) and composite providers.
+pub mod root_of_trust;
 /// Secure time / monotonic floor helpers (best-effort without TPM/HSM).
 #[cfg(feature = "std")]
 pub mod time;

--- a/src/security/provider.rs
+++ b/src/security/provider.rs
@@ -1,3 +1,4 @@
+use crate::crypto::traits::PqcKEM;
 use crate::{Error, Result};
 use aes_gcm::{
     aead::{Aead, KeyInit},
@@ -11,6 +12,7 @@ use pqcrypto_traits::sign::{DetachedSignature, SecretKey as _};
 use rand_core::{OsRng, RngCore};
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
+use zeroize::Zeroize;
 
 fn ensure_pqc_data_dir() -> Result<()> {
     let dir = Path::new("pqc-data");
@@ -60,6 +62,47 @@ pub trait SecurityProvider: Send + Sync {
 
     /// Decrypt a ciphertext using the internal Kyber Secret Key.
     fn decrypt(&self, ciphertext: &[u8]) -> Result<Vec<u8>>;
+
+    /// Decapsulate a Kyber KEM capsule and return the shared secret (32 bytes).
+    ///
+    /// This is a primitive used for post-compromise recovery and anti-replay roots in protocols
+    /// that need a *KEM-derived secret* (not a decrypted plaintext).
+    ///
+    /// Default behavior:
+    /// - If the provider allows exporting identity secrets, this method uses the exported Kyber
+    ///   secret key to decapsulate in software.
+    /// - Hardware providers should override this to use the device's KEM engine (TPM/HSM/TEE).
+    fn kem_decapsulate(&self, kem_ciphertext: &[u8]) -> Result<[u8; 32]> {
+        let exported = self.export_secret_keys().ok_or_else(|| {
+            Error::CryptoError("KEM decapsulation not supported by this provider".into())
+        })?;
+
+        // Determine Kyber level from secret key length.
+        let kyber = match exported.kem_sk.len() {
+            1632 => crate::Kyber::new_with_level(crate::KyberSecurityLevel::Kyber512),
+            2400 => crate::Kyber::new_with_level(crate::KyberSecurityLevel::Kyber768),
+            3168 => crate::Kyber::new_with_level(crate::KyberSecurityLevel::Kyber1024),
+            len => {
+                return Err(Error::CryptoError(format!(
+                    "Invalid Kyber SK length for kem_decapsulate: {}",
+                    len
+                )))
+            }
+        };
+
+        let mut ss = kyber.decapsulate(&exported.kem_sk, kem_ciphertext)?;
+        if ss.len() != 32 {
+            ss.zeroize();
+            return Err(Error::CryptoError(format!(
+                "Unexpected Kyber shared secret length: {}",
+                ss.len()
+            )));
+        }
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&ss);
+        ss.zeroize();
+        Ok(out)
+    }
 
     /// Sign a message using the internal Falcon Secret Key.
     fn sign(&self, message: &[u8]) -> Result<Vec<u8>>;
@@ -286,6 +329,34 @@ impl SecurityProvider for SoftwareSecurityProvider {
         crate::security::hybrid::decrypt_with_exchange(&self.kyber_sk, ciphertext, |peer_pk| {
             self.x25519_exchange(peer_pk)
         })
+    }
+
+    fn kem_decapsulate(&self, kem_ciphertext: &[u8]) -> Result<[u8; 32]> {
+        // Determine Kyber level from Secret Key Length.
+        let kyber = match self.kyber_sk.len() {
+            1632 => crate::Kyber::new_with_level(crate::KyberSecurityLevel::Kyber512),
+            2400 => crate::Kyber::new_with_level(crate::KyberSecurityLevel::Kyber768),
+            3168 => crate::Kyber::new_with_level(crate::KyberSecurityLevel::Kyber1024),
+            len => {
+                return Err(Error::CryptoError(format!(
+                    "Invalid Kyber SK length for kem_decapsulate: {}",
+                    len
+                )))
+            }
+        };
+
+        let mut ss = kyber.decapsulate(&self.kyber_sk, kem_ciphertext)?;
+        if ss.len() != 32 {
+            ss.zeroize();
+            return Err(Error::CryptoError(format!(
+                "Unexpected Kyber shared secret length: {}",
+                ss.len()
+            )));
+        }
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&ss);
+        ss.zeroize();
+        Ok(out)
     }
 
     fn sign(&self, message: &[u8]) -> Result<Vec<u8>> {

--- a/src/security/root_of_trust.rs
+++ b/src/security/root_of_trust.rs
@@ -1,0 +1,280 @@
+use crate::security::provider::SecurityProvider;
+use crate::{Error, Result};
+use aes_gcm::{
+    aead::{Aead, KeyInit},
+    Aes256Gcm, Nonce,
+};
+use rand_core::{OsRng, RngCore};
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+fn ensure_pqc_data_dir() -> Result<()> {
+    let dir = Path::new("pqc-data");
+    if !dir.exists() {
+        std::fs::create_dir_all(dir).map_err(Error::IoError)?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(e) = std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700)) {
+            return Err(Error::IoError(e));
+        }
+    }
+    Ok(())
+}
+
+fn sealed_blob_path(label: &str) -> PathBuf {
+    // Never use `label` as a path fragment directly: it may carry path separators and trigger
+    // traversal/overwrite. Hash it into a stable, filesystem-safe name.
+    let digest = Sha256::digest(label.as_bytes());
+    Path::new("pqc-data").join(format!("sealed_{}.bin", hex::encode(digest)))
+}
+
+/// Hardware Root of Trust (RoT) boundary.
+///
+/// This is the interface we *actually* need for IIoT-critical anti-rollback:
+/// - rollback-resistant monotonic counters (TPM NV counters / TEE monotonic storage / HSM)
+/// - rollback-resistant sealing (eg. TPM sealed objects bound to NV counters)
+///
+/// Invariant: When `is_rollback_resistant_storage() == true`, callers may treat
+/// `seal_data/unseal_data` and `sealed_monotonic_u64_*` as **anti-rollback** primitives.
+/// When `false`, these are best-effort and can be rolled back by restoring older blobs.
+pub trait RootOfTrust: Send + Sync {
+    /// Human-readable kind string for observability.
+    fn rot_kind(&self) -> &'static str;
+
+    /// Whether the RoT provides rollback-resistant storage/counters.
+    fn is_rollback_resistant_storage(&self) -> bool;
+
+    /// Seal data to persistent storage under `label`.
+    fn seal_data(&self, label: &str, data: &[u8]) -> Result<()>;
+
+    /// Unseal data from persistent storage under `label`.
+    fn unseal_data(&self, label: &str) -> Result<Vec<u8>>;
+
+    /// Read a sealed monotonic `u64` counter.
+    fn sealed_monotonic_u64_get(&self, label: &str) -> Result<Option<u64>>;
+
+    /// Advance a sealed monotonic counter if `candidate > current`.
+    ///
+    /// Returns `Ok(true)` when the counter advanced, `Ok(false)` otherwise.
+    fn sealed_monotonic_u64_advance_to(&self, label: &str, candidate: u64) -> Result<bool>;
+
+    /// Increment a sealed monotonic counter by 1, persist it, and return the new value.
+    fn sealed_monotonic_u64_increment(&self, label: &str) -> Result<u64>;
+}
+
+/// Best-effort RoT implementation for dev/test: AES-GCM sealed blobs on the filesystem.
+///
+/// This does **not** provide rollback resistance.
+///
+/// Intended usage:
+/// - In production, replace this with a TPM/TEE/HSM-backed RoT.
+/// - In tests/demos, this gives deterministic semantics for the RoT boundary without pretending to
+///   provide anti-rollback.
+pub struct SoftwareRootOfTrust {
+    master_key: [u8; 32],
+}
+
+impl SoftwareRootOfTrust {
+    /// Create a new RoT instance with an explicit master key.
+    pub fn new(master_key: [u8; 32]) -> Self {
+        Self { master_key }
+    }
+
+    fn sealing_key(&self, label: &str) -> aes_gcm::Key<Aes256Gcm> {
+        let mut hasher = Sha256::new();
+        hasher.update(self.master_key);
+        hasher.update(label.as_bytes());
+        let digest = hasher.finalize();
+        *aes_gcm::Key::<Aes256Gcm>::from_slice(&digest)
+    }
+}
+
+impl RootOfTrust for SoftwareRootOfTrust {
+    fn rot_kind(&self) -> &'static str {
+        "software-rot"
+    }
+
+    fn is_rollback_resistant_storage(&self) -> bool {
+        false
+    }
+
+    fn seal_data(&self, label: &str, data: &[u8]) -> Result<()> {
+        ensure_pqc_data_dir()?;
+        let path = sealed_blob_path(label);
+        let key = self.sealing_key(label);
+        let cipher = Aes256Gcm::new(&key);
+        let mut nonce_bytes = [0u8; 12];
+        OsRng.fill_bytes(&mut nonce_bytes);
+        let nonce = Nonce::from_slice(&nonce_bytes);
+
+        let ciphertext = cipher
+            .encrypt(nonce, data)
+            .map_err(|_| Error::CryptoError("RoT seal encryption failed".into()))?;
+
+        let mut out = Vec::with_capacity(12 + ciphertext.len());
+        out.extend_from_slice(&nonce_bytes);
+        out.extend_from_slice(&ciphertext);
+        crate::persistence::AtomicFileStore::write(&path, &out)
+    }
+
+    fn unseal_data(&self, label: &str) -> Result<Vec<u8>> {
+        const MAX_SEALED_BYTES: usize = 1024 * 1024; // 1 MiB anti-OOM guardrail
+
+        if !Path::new("pqc-data").exists() {
+            return Err(Error::IoError(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "pqc-data missing",
+            )));
+        }
+
+        let path = sealed_blob_path(label);
+        let blob = crate::persistence::AtomicFileStore::read_with_limit(&path, MAX_SEALED_BYTES)?;
+        if blob.len() < 12 {
+            return Err(Error::CryptoError("Sealed data too short".into()));
+        }
+        let (nonce_bytes, ciphertext) = blob.split_at(12);
+        let key = self.sealing_key(label);
+        let cipher = Aes256Gcm::new(&key);
+        cipher
+            .decrypt(Nonce::from_slice(nonce_bytes), ciphertext)
+            .map_err(|_| Error::CryptoError("Sealed data authentication failed".into()))
+    }
+
+    fn sealed_monotonic_u64_get(&self, label: &str) -> Result<Option<u64>> {
+        match self.unseal_data(label) {
+            Ok(blob) => {
+                if blob.len() != 8 {
+                    return Err(Error::CryptoError(format!(
+                        "Invalid sealed u64 length for {}: {}",
+                        label,
+                        blob.len()
+                    )));
+                }
+                let mut buf = [0u8; 8];
+                buf.copy_from_slice(&blob);
+                Ok(Some(u64::from_be_bytes(buf)))
+            }
+            Err(Error::IoError(e)) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn sealed_monotonic_u64_advance_to(&self, label: &str, candidate: u64) -> Result<bool> {
+        let current = self.sealed_monotonic_u64_get(label)?.unwrap_or(0);
+        if candidate > current {
+            self.seal_data(label, &candidate.to_be_bytes())?;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    fn sealed_monotonic_u64_increment(&self, label: &str) -> Result<u64> {
+        let current = self.sealed_monotonic_u64_get(label)?.unwrap_or(0);
+        let next = current.saturating_add(1).max(1);
+        self.seal_data(label, &next.to_be_bytes())?;
+        Ok(next)
+    }
+}
+
+/// Composite `SecurityProvider` that delegates:
+/// - long-term cryptographic operations to `crypto`
+/// - sealing and monotonic state to a `RootOfTrust` (`rot`)
+///
+/// This models the production reality where PQC primitives may live in software today, while
+/// anti-rollback and key-wrapping are anchored in a TPM/TEE/HSM.
+pub struct CompositeSecurityProvider {
+    crypto: Arc<dyn SecurityProvider>,
+    rot: Arc<dyn RootOfTrust>,
+}
+
+impl CompositeSecurityProvider {
+    /// Construct a composite provider from:
+    /// - a cryptographic provider (`crypto`) for signatures/KEM/X25519, and
+    /// - a root-of-trust (`rot`) for rollback-resistant sealing and monotonic counters.
+    pub fn new(crypto: Arc<dyn SecurityProvider>, rot: Arc<dyn RootOfTrust>) -> Self {
+        Self { crypto, rot }
+    }
+
+    /// Observability: the underlying crypto provider kind string.
+    pub fn crypto_kind(&self) -> &'static str {
+        self.crypto.provider_kind()
+    }
+
+    /// Observability: the underlying root-of-trust kind string.
+    pub fn rot_kind(&self) -> &'static str {
+        self.rot.rot_kind()
+    }
+}
+
+impl SecurityProvider for CompositeSecurityProvider {
+    fn kem_public_key(&self) -> &[u8] {
+        self.crypto.kem_public_key()
+    }
+
+    fn sig_public_key(&self) -> &[u8] {
+        self.crypto.sig_public_key()
+    }
+
+    fn decrypt(&self, ciphertext: &[u8]) -> Result<Vec<u8>> {
+        self.crypto.decrypt(ciphertext)
+    }
+
+    fn kem_decapsulate(&self, kem_ciphertext: &[u8]) -> Result<[u8; 32]> {
+        self.crypto.kem_decapsulate(kem_ciphertext)
+    }
+
+    fn sign(&self, message: &[u8]) -> Result<Vec<u8>> {
+        self.crypto.sign(message)
+    }
+
+    fn export_secret_keys(&self) -> Option<crate::security::provider::ExportedIdentitySecrets> {
+        self.crypto.export_secret_keys()
+    }
+
+    fn provider_kind(&self) -> &'static str {
+        "composite"
+    }
+
+    fn is_rollback_resistant_storage(&self) -> bool {
+        self.rot.is_rollback_resistant_storage()
+    }
+
+    fn seal_data(&self, label: &str, data: &[u8]) -> Result<()> {
+        self.rot.seal_data(label, data)
+    }
+
+    fn unseal_data(&self, label: &str) -> Result<Vec<u8>> {
+        self.rot.unseal_data(label)
+    }
+
+    fn sealed_monotonic_u64_get(&self, label: &str) -> Result<Option<u64>> {
+        self.rot.sealed_monotonic_u64_get(label)
+    }
+
+    fn sealed_monotonic_u64_advance_to(&self, label: &str, candidate: u64) -> Result<bool> {
+        self.rot.sealed_monotonic_u64_advance_to(label, candidate)
+    }
+
+    fn sealed_monotonic_u64_increment(&self, label: &str) -> Result<u64> {
+        self.rot.sealed_monotonic_u64_increment(label)
+    }
+
+    fn generate_quote(
+        &self,
+        pcr_indices: &[u32],
+        nonce: &[u8],
+    ) -> Result<crate::attestation::quote::AttestationQuote> {
+        self.crypto.generate_quote(pcr_indices, nonce)
+    }
+
+    fn x25519_public_key(&self) -> [u8; 32] {
+        self.crypto.x25519_public_key()
+    }
+
+    fn x25519_exchange(&self, peer_pk: [u8; 32]) -> Result<[u8; 32]> {
+        self.crypto.x25519_exchange(peer_pk)
+    }
+}

--- a/src/security/tpm.rs
+++ b/src/security/tpm.rs
@@ -417,6 +417,40 @@ impl SecurityProvider for SoftwareTpm {
             .map_err(|e| Error::CryptoError(format!("TPM Decrypt Fail: {:?}", e)))
     }
 
+    fn kem_decapsulate(&self, kem_ciphertext: &[u8]) -> Result<[u8; 32]> {
+        let state = self
+            .state
+            .lock()
+            .map_err(|_| Error::CryptoError("TPM Lock Poisoned".into()))?;
+
+        let kyber = match state.kem_sk.len() {
+            1632 => Kyber::new_with_level(crate::KyberSecurityLevel::Kyber512),
+            2400 => Kyber::new_with_level(crate::KyberSecurityLevel::Kyber768),
+            3168 => Kyber::new_with_level(crate::KyberSecurityLevel::Kyber1024),
+            len => {
+                return Err(Error::CryptoError(format!(
+                    "Invalid Kyber SK length for kem_decapsulate: {}",
+                    len
+                )))
+            }
+        };
+
+        let mut ss = kyber
+            .decapsulate(&state.kem_sk, kem_ciphertext)
+            .map_err(|e| Error::CryptoError(format!("TPM KEM decap fail: {:?}", e)))?;
+        if ss.len() != 32 {
+            ss.zeroize();
+            return Err(Error::CryptoError(format!(
+                "Unexpected Kyber shared secret length: {}",
+                ss.len()
+            )));
+        }
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&ss);
+        ss.zeroize();
+        Ok(out)
+    }
+
     fn export_secret_keys(&self) -> Option<crate::security::provider::ExportedIdentitySecrets> {
         // TPM keys are non-exportable by design.
         None

--- a/tests/mqtt_invariants.rs
+++ b/tests/mqtt_invariants.rs
@@ -209,7 +209,72 @@ fn mqtt_session_ratchet_establishes_and_binds_topic_and_rejects_replay(
     let topic_reply = format!("secure/session_reply_{}", suffix);
     alice.subscribe(&topic_reply)?;
 
+    // Sniff the responder's first session packet and ensure it carries a KEM ciphertext.
+    // This is the in-session PQC PCS refresh signal for the hybrid DH+KEM ratchet.
+    let (reply_tx, reply_rx) = std::sync::mpsc::channel::<Vec<u8>>();
+    let (reply_ready_tx, reply_ready_rx) = std::sync::mpsc::channel::<()>();
+    let topic_reply_sniff = topic_reply.clone();
+    let bob_id_sniff = bob_id.clone();
+    let reply_handle = std::thread::spawn(move || {
+        let mut opts = MqttOptions::new("sniffer_reply", "localhost", port);
+        opts.set_clean_session(true);
+        let (mut sniff_client, mut sniff_conn) = RumqttClient::new(opts, 10);
+        sniff_client
+            .subscribe(&topic_reply_sniff, QoS::AtLeastOnce)
+            .expect("sniffer reply subscribe");
+
+        let mut ready_sent = false;
+        for notification in sniff_conn.iter() {
+            if let Ok(Event::Incoming(Packet::SubAck(_))) = notification {
+                if !ready_sent {
+                    let _ = reply_ready_tx.send(());
+                    ready_sent = true;
+                }
+                continue;
+            }
+            if let Ok(Event::Incoming(Packet::Publish(p))) = notification {
+                if p.payload.len() < 4 {
+                    continue;
+                }
+                let id_len = u16::from_be_bytes([p.payload[0], p.payload[1]]) as usize;
+                if p.payload.len() < 2 + id_len + 1 {
+                    continue;
+                }
+                let id_bytes = &p.payload[2..2 + id_len];
+                if let Ok(id) = std::str::from_utf8(id_bytes) {
+                    if id != bob_id_sniff {
+                        continue;
+                    }
+                } else {
+                    continue;
+                }
+                let _ = reply_tx.send(p.payload.to_vec());
+                break;
+            }
+        }
+        let _ = sniff_client.disconnect();
+    });
+
+    reply_ready_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("reply sniffer not ready");
+
     bob.publish_encrypted(&topic_reply, b"SESSION_REPLY", &alice_id)?;
+
+    let raw_reply = reply_rx
+        .recv_timeout(Duration::from_secs(3))
+        .expect("did not sniff responder session packet");
+    reply_handle.join().expect("reply sniffer thread panicked");
+
+    // Wire format: [sender_id_len:u16][sender_id][v=4][session_id:16][dh_pub:32][msg_num:u32][pn:u32][kem_ct_len:u16]...
+    let id_len = u16::from_be_bytes([raw_reply[0], raw_reply[1]]) as usize;
+    let offset = 2 + id_len;
+    assert_eq!(raw_reply[offset], 4, "Expected session packet version v4");
+    let kem_ct_len = u16::from_be_bytes([raw_reply[offset + 57], raw_reply[offset + 58]]) as usize;
+    assert!(
+        kem_ct_len > 0,
+        "Expected responder to carry KEM ciphertext on first ratchet send"
+    );
 
     let start = Instant::now();
     let mut got_reply = 0u32;
@@ -226,6 +291,162 @@ fn mqtt_session_ratchet_establishes_and_binds_topic_and_rejects_replay(
     }
 
     assert_eq!(got_reply, 1, "Expected exactly one session reply delivery");
+
+    Ok(())
+}
+
+#[test]
+fn mqtt_session_v4_rejects_dh_ratchet_without_kem_after_established(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let port = 29841;
+    common::start_mqtt_broker(port);
+    let suffix: u32 = rand::random();
+
+    let key_prefix = format!("pqc/session_downgrade_keys_{}/", suffix);
+    let topic = format!("secure/session_downgrade_{}", suffix);
+
+    let alice_id = format!("alice_downgrade_{}", suffix);
+    let bob_id = format!("bob_downgrade_{}", suffix);
+
+    let mut alice = SecureMqttClient::new("localhost", port, &alice_id)?
+        .with_strict_mode(false)
+        .with_key_prefix(&key_prefix);
+    let mut bob = SecureMqttClient::new("localhost", port, &bob_id)?
+        .with_strict_mode(false)
+        .with_key_prefix(&key_prefix);
+
+    alice.bootstrap()?;
+    bob.bootstrap()?;
+
+    bob.subscribe(&topic)?;
+
+    wait_for_key_exchange(&mut alice, &mut bob, &alice_id, &bob_id)?;
+
+    // Establish session (Alice -> Bob).
+    alice.initiate_session(&bob_id)?;
+    let start = Instant::now();
+    while start.elapsed() < Duration::from_secs(5) {
+        alice.poll(|_, _| {})?;
+        bob.poll(|_, _| {})?;
+        if alice.has_session(&bob_id) && bob.has_session(&alice_id) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(alice.has_session(&bob_id));
+    assert!(bob.has_session(&alice_id));
+
+    // Sniff a valid v4 packet to extract the session_id.
+    let (tx, rx) = std::sync::mpsc::channel::<Vec<u8>>();
+    let (ready_tx, ready_rx) = std::sync::mpsc::channel::<()>();
+    let topic_sniff = topic.clone();
+    let alice_id_sniff = alice_id.clone();
+    let sniff_handle = std::thread::spawn(move || {
+        let mut opts = MqttOptions::new("sniffer_downgrade", "localhost", port);
+        opts.set_clean_session(true);
+        let (mut sniff_client, mut sniff_conn) = RumqttClient::new(opts, 10);
+        sniff_client
+            .subscribe(&topic_sniff, QoS::AtLeastOnce)
+            .expect("sniffer subscribe");
+
+        let mut ready_sent = false;
+        for notification in sniff_conn.iter() {
+            if let Ok(Event::Incoming(Packet::SubAck(_))) = notification {
+                if !ready_sent {
+                    let _ = ready_tx.send(());
+                    ready_sent = true;
+                }
+                continue;
+            }
+            if let Ok(Event::Incoming(Packet::Publish(p))) = notification {
+                if p.payload.len() < 4 {
+                    continue;
+                }
+                let id_len = u16::from_be_bytes([p.payload[0], p.payload[1]]) as usize;
+                if p.payload.len() < 2 + id_len + 1 {
+                    continue;
+                }
+                let id_bytes = &p.payload[2..2 + id_len];
+                if let Ok(id) = std::str::from_utf8(id_bytes) {
+                    if id != alice_id_sniff {
+                        continue;
+                    }
+                } else {
+                    continue;
+                }
+                let _ = tx.send(p.payload.to_vec());
+                break;
+            }
+        }
+        let _ = sniff_client.disconnect();
+    });
+
+    ready_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("sniffer not ready");
+
+    alice.publish_encrypted(&topic, b"HELLO", &bob_id)?;
+    let raw = rx
+        .recv_timeout(Duration::from_secs(3))
+        .expect("did not sniff initial session packet");
+    sniff_handle.join().expect("sniffer thread panicked");
+
+    // Extract session_id from the sniffed packet.
+    let id_len = u16::from_be_bytes([raw[0], raw[1]]) as usize;
+    let offset = 2 + id_len;
+    assert_eq!(raw[offset], 4, "Expected session packet version v4");
+    let mut session_id = [0u8; 16];
+    session_id.copy_from_slice(&raw[offset + 1..offset + 17]);
+
+    // Ensure Bob accepted the initial plaintext (so recv_chain_key is established).
+    let start = Instant::now();
+    let mut got_hello = 0u32;
+    while start.elapsed() < Duration::from_secs(3) {
+        bob.poll(|t, p| {
+            if t == topic && p == b"HELLO" {
+                got_hello += 1;
+            }
+        })?;
+        if got_hello >= 1 {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert_eq!(got_hello, 1);
+
+    // Craft a malicious ratchet packet: new dh_pub but kem_ct_len=0.
+    // After the receiving chain is established, this must be rejected as a downgrade.
+    let sender_id_bytes = alice_id.as_bytes();
+    let sender_id_len = sender_id_bytes.len() as u16;
+    let mut malicious = Vec::new();
+    malicious.extend_from_slice(&sender_id_len.to_be_bytes());
+    malicious.extend_from_slice(sender_id_bytes);
+    malicious.push(4); // v4
+    malicious.extend_from_slice(&session_id);
+    malicious.extend_from_slice(&[0xAAu8; 32]); // new dh_pub
+    malicious.extend_from_slice(&0u32.to_be_bytes()); // msg_num
+    malicious.extend_from_slice(&0u32.to_be_bytes()); // pn
+    malicious.extend_from_slice(&0u16.to_be_bytes()); // kem_ct_len=0 (downgrade)
+    malicious.extend_from_slice(&16u32.to_be_bytes()); // ct_len
+    malicious.extend_from_slice(&[0u8; 16]); // bogus tag-only ciphertext
+
+    publish_raw(&topic, port, malicious)?;
+
+    // Bob must not deliver any new plaintext.
+    let start = Instant::now();
+    let mut got_any = false;
+    while start.elapsed() < Duration::from_millis(500) {
+        bob.poll(|t, _p| {
+            if t == topic {
+                got_any = true;
+            }
+        })?;
+        if got_any {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(!got_any, "Downgrade packet must not be delivered");
 
     Ok(())
 }


### PR DESCRIPTION
- Introduce RootOfTrust + CompositeSecurityProvider, sealed monotonic u64 helpers, and SecureTimeFloor
- Upgrade MQTT sessions to v4 hybrid DH+KEM double ratchet with budgets and downgrade resistance
- Add OSCORE client backend for CoAP behind coap-oscore feature and update security docs/invariants